### PR TITLE
Increase range for peer dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,8 +41,8 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.18.9",


### PR DESCRIPTION
Hi Alvar! Thanks for creating this great package - love the approach you took 👏

While installing, I ran into this annoying npm --legacy-peer-deps issue. So I thought increasing the compatibility range for peer deps might be a good idea - assuming that the package works with React 17 too (though I don't know why it shouldn't). 